### PR TITLE
Update my company name in Program Committee list

### DIFF
--- a/src/site/2015/_program_committee.md
+++ b/src/site/2015/_program_committee.md
@@ -1,5 +1,5 @@
 - [Michael Fogus](http://www.fogus.me/) (Cognitect)
-- [Rein Henrichs](http://reinh.com/) (AlephCloud)
+- [Rein Henrichs](http://reinh.com/) (PivotMail)
 - [Jessica Kerr](http://jessitron.com/) (Outpace Systems)
 - [Tony Morris](http://tmorris.net/) (NICTA)
 - [Max Swadling](http://maxs.io/) (Apple)


### PR DESCRIPTION
We made this change recently and didn't announce it very well, so it isn't surprising that I'm listed with the old name. Thanks for adding this info for me in the first place.