### PR TITLE
Improvements to the Call for Tutorials (change from easychair to goog…

### DIFF
--- a/site/2016/call-for-tutorials.md
+++ b/site/2016/call-for-tutorials.md
@@ -3,84 +3,55 @@
 
 # CUFP 2016 Call for Tutorials
 
-Commercial Users of Functional Programming (CUFP) is an annual meeting
-co-located with the International Conference on Functional Programming which
-this year will take place in Nara, Japan from the 22nd to 24th of September
-2016.
+The Commercial Users of Functional Programming (CUFP) is an annual meeting co-located with the International Conference on Functional Programming (ICFP) which this year will take place in Nara, Japan from the 22nd to 24th of September 2016.
 
-CUFP aims to bridge the gap between academia and users applying functional
-programming in practice. CUFP provides high-quality practical tutorials covering
-state-of-the-art techniques and tools for functional programming. There will be
-a mix of tutorials on introduction and advanced level, such that anyone that
-wants to learn something new has an opportunity to do so.
+CUFP aims to bridge the gap between academia and users applying functional programming in practice. CUFP provides high-quality practical tutorials covering state-of-the-art techniques and tools for functional programming. There will be a mix of tutorials on introduction and advanced level, such that anyone that wants to learn something new has an opportunity to do so.
 
-We are seeking proposals for half-day tutorials to be presented during the first
-two days of the meeting, 22nd and 24th of September. Submission deadline is June
-26th, but the earlier you submit, the better!
+We are seeking proposals for half-day tutorials to be presented during the first two days of the meeting, 22nd and 24th of September. Submission deadline is June 26th, but the earlier you submit, the better!
 
-Among the suggested topics for tutorials are:
+## Please read these guidelines before submitting:
 
-* Introductions to functional programming languages. In the past we have had
-  introductions to Clojure, Erlang, F#, F*, Haskell, ML, OCaml, Scala, Scheme
-  and others.
+* You should have significant speaking experience, preferably with long form workshops similar to the one you're proposing.
+* You should be an expert user or advocate for this technology (creator, implementor, standards committee expert, author, known speaker, etc).
+* Your title should be simple and direct and clearly mention the primary technology you wish to cover.
+* Your title or abstract should clearly indicate whether the workshop is an intro level, intermediate, or advanced topic.
 
-* Advanced programming languages concepts and applications, such as Lens, Agda,
-  Idris and others
+## Among the suggested topics for tutorials are:
 
-* Applying functional programming in particular areas, including the web
-  (Servant), high-performance computing, finance.
+* Introductions to functional programming languages. In the past we have had introductions to Clojure, Erlang, F#, F*, Haskell, ML, OCaml, Scala, Scheme and others.
+* Advanced programming languages, concepts and applications (e.g. Lens, Liquid-Haskell, Agda, Idris, etc.)
+* Applying functional programming in particular areas, including Web, high-performance computing, finance.
+* Tools and techniques supporting state of the art functional programming. In the past we have had tutorials on QuickCheck, Elm and others.
+* Theory. Type theory, category theory, abstract algebra, ongoing or new research, and anything useful or interesting to functional programmers.
 
-* Tools and techniques supporting state of the art functional programming. In
-  the past we have had tutorials on QuickCheck, Elm and others.
-
-
-Tutorial proposals should address the following points:
+## Tutorial proposals should address the following points:
 
 * Title
+* Abstract (about 200 words)
+* Tutorial Objectives: by the end of this tutorial you will be able to …
+* Speaker Bio: Joe Bloggs is ...
+* Infrastructure required: For example, will participants need access to a particular system? Do they need to download anything prior to the tutorial? Can they be expected to have this on a laptop, or does it need to be provided by the meeting?
+* Other minor information which will help us market your tutorial.
 
-* Abstract (about 200 words) including
+Tutorials should be submitted using the following talk submission form. Deadline for submission is June 26, 2016. Notification of acceptance is two weeks later.
 
-   * Tutorial Objectives: by the end of this tutorial you will be able to …
+## Tutorial Agreement
 
-   * Intended audience: e.g. beginners, those with a working knowledge of X, …
+While CUFP does not pay tutors, they will be compensated with admission credits to CUFP and ICFP, as outlined below.
 
-   * Speaker Bio: Joe Bloggs is ...
+* If a tutorial has 5 or more registrants, the tutor will receive free admission to CUFP, including the two days of tutorials and the day of the CUFP workshop.
+* If a tutorial has 10 or more registrants, the tutorialist will additionally receive a $250 voucher that can be used to register for any of the other ICFP events, including ICFP itself.
 
-   * Infrastructure required: For example, will participants need access to a
-     particular system? Do they need to download anything prior to the tutorial?
-     Can they be expected to have this on a laptop, or does it need to be
-     provided by the meeting?
+Note that we reserve the right to cancel tutorials with fewer than 5 registrants, but we will try hard to avoid having to do so. No compensation will be awarded for cancelled tutorials.
 
-   * Other minor information which will help us market your tutorial.
+[Register here to submit a CUFP tutorial proposal.](http://goo.gl/forms/qoyK9qYPZhiDPSzO2)
 
-Tutorials should be submitted using the following talk submission form. Deadline
-for submission is June 26, 2016. Notification of acceptance is two weeks later.
+If you have any questions, email to
 
-Tutorial Agreement
+* Roman Gonzalez: roman at unbounce dot com
+* Takayuki Muranushi: muranushi at gmail dot com
 
-While CUFP does not pay tutors, they will be compensated with admission credits
-to CUFP and ICFP, as outlined below.
-
-- If a tutorial has 5 or more registrants, the tutor will receive free admission
-  to CUFP, including the two days of tutorials and the day of the CUFP workshop.
-
-- If a tutorial has 10 or more registrants, the tutorialist will additionally
-  receive a $250 voucher that can be used to register for any of the other ICFP
-  events, including ICFP itself.
-
-Note that we reserve the right to cancel tutorials with fewer than 5
-registrants, but we will try hard to avoid having to do so. No compensation will
-be awarded for cancelled tutorials.
-
-[Register here to submit a CUFP tutorial proposal.](https://easychair.org/conferences/?conf=cufp2016)
-
-If you have any questions, email Roman Gonzalez: roman at unbounce dot com or
-Takayuki Muranushi: muranushi at gmail dot com
-
-The 2016 conference is going to be held in Nara, Japan from September 22nd-24th Once
-again, it is co-located with [ICFP 2016](http://icfpconference.org/icfp2016).
-
-CUFP tweets [@cufpconference](https://twitter.com/cufpconference).
+You can follow CUFP over twitter to get semi-regular updates @cufpconference
 
 </div>
 </div>


### PR DESCRIPTION
…le forms)

ping @agarwal 

I'm changing the call for tutorials to go to a link in Google Forms, I was trying to use easychair.org as Thomas used it last year, but I haven't received any submission yet, and I'm concerned there is something wrong about configuration of this tooling.

I'm going to be submitting emails to mailing lists of the following communities:

* Haskell
* OCaml
* Scala
* Clojure
* Erlang
* Purescript
* Elm

If by any chance you know someone that might be interested in submitting a workshop proposal, please send them to the new page. I'm a bit stressed there is no feedback so far on the tutorials.

Cheers.